### PR TITLE
fix: harden judge prompt and parser for reliable JSON grading

### DIFF
--- a/scripts/lib_grading.py
+++ b/scripts/lib_grading.py
@@ -341,7 +341,7 @@ def _parse_judge_response(transcript: List[Dict[str, Any]]) -> Dict[str, Any]:
     # Fallback: try to extract numeric scores from prose responses.
     # Models sometimes return "Total: 0.72" or "Overall score: 0.65" instead of JSON.
     score_pattern = re.search(
-        r"(?:total|overall|final)\s*(?:score)?[:\s]*([01]\.?\d*)",
+        r"(?:total|overall|final)\s*(?:score)?[:\s]*(0\.\d+|1\.0+)",
         raw_text,
         re.IGNORECASE,
     )


### PR DESCRIPTION
## Problem

When running PinchBench with OpenClaw agents, the LLM judge (e.g. `anthropic/claude-opus-4.5`) treats the grading prompt as a full agentic task — calling tools (`Write`, `exec`, etc.), creating files in the workspace, and returning prose instead of JSON.

This causes `_parse_judge_response` to fail on **every** LLM-graded task, resulting in 0 scores across the board. In our run (Opus 4 agent, 23 tasks), 20/23 tasks scored 0 due to this.

### Evidence

Judge transcript shows tool usage + prose instead of JSON:
```
ASSISTANT: Now I have everything I need to evaluate task_22. Let me write the result...
ASSISTANT: Now update the evaluation report and write the final overall result.json...
```

Log shows repeated failures:
```
WARNING - Failed to parse judge JSON response
WARNING - Failed to parse judge JSON response  
WARNING - Failed to parse judge JSON response
```

## Fix

### 1. Stricter judge prompt (`_build_judge_prompt`)

Added explicit `CRITICAL RULES` section:
- No tool calls (Read, Write, exec, etc.)
- No file creation or commands  
- No prose outside the JSON object
- Includes exact JSON template as example

### 2. Regex fallback in `_parse_judge_response`

When JSON extraction fails, attempts to extract a total score from prose using pattern matching (e.g. `Total: 0.72`, `Overall score: 0.65`). Provides graceful degradation when models still return prose despite the prompt.

## Testing

Tested with `anthropic/claude-opus-4-6` as agent + `anthropic/claude-opus-4.5` as judge on OpenClaw.

**Before:** 20/23 tasks scored 0 (all LLM-judged tasks failed to parse)  
**After:** Judge prompt prevents tool usage and enforces JSON-only output; fallback catches any remaining prose responses.