### PR TITLE
fix: Support custom providers and configurable judge message limit

### DIFF
--- a/scripts/lib_agent.py
+++ b/scripts/lib_agent.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -15,18 +16,21 @@ from lib_tasks import Task
 
 
 logger = logging.getLogger(__name__)
-MAX_OPENCLAW_MESSAGE_CHARS = 4000
+MAX_OPENCLAW_MESSAGE_CHARS = int(os.environ.get("PINCHBENCH_MAX_MSG_CHARS", "4000"))
 
 
 def slugify_model(model_id: str) -> str:
     return model_id.replace("/", "-").replace(".", "-")
 
 
+KNOWN_PROVIDERS = ("openrouter/", "vllm/", "ollama/", "nvidia-api/", "nvidia-nemotron/")
+
+
 def normalize_model_id(model_id: str) -> str:
     """Ensure model id is provider-qualified for OpenClaw."""
     if "/" not in model_id:
         return model_id
-    if model_id.startswith("openrouter/"):
+    if any(model_id.startswith(p) for p in KNOWN_PROVIDERS):
         return model_id
     return f"openrouter/{model_id}"
 


### PR DESCRIPTION
## Summary

- **Custom provider support**: `normalize_model_id` now recognises multiple provider prefixes (`vllm/`, `ollama/`, `nvidia-api/`, `nvidia-nemotron/`) via a `KNOWN_PROVIDERS` list, so they are no longer incorrectly wrapped with `openrouter/`.
- **Configurable message chunking limit**: `MAX_OPENCLAW_MESSAGE_CHARS` can now be overridden via the `PINCHBENCH_MAX_MSG_CHARS` environment variable (default unchanged at 4000). When the judge prompt exceeds the chunk size it gets split into multiple messages, which causes non-deterministic judge failures because the judge model responds prematurely to partial prompts. Setting `PINCHBENCH_MAX_MSG_CHARS=200000` eliminates this issue.
- **Cleanup**: Removed unused `verbose` plumbing from internal grading helpers (`verbose` flag kept on `grade_task` for API compatibility with `benchmark.py`) and removed unused `Optional` import.

## Test plan

- [x] Verified that existing models prefixed with `openrouter/` are still handled correctly
- [x] Verified that `vllm/`, `ollama/`, `nvidia-api/`, `nvidia-nemotron/` prefixed model IDs pass through without `openrouter/` wrapping
- [x] Ran full benchmark suite 3× with `PINCHBENCH_MAX_MSG_CHARS=200000` — judge scores became deterministic and consistent across runs
- [x] Ran full benchmark suite 3× without the env var set — default behaviour (4000) is unchanged

Made with [Cursor](https://cursor.com)