### PR TITLE
fix(task_10): support OpenClaw/Claude Code read tool name in read_config grader

### DIFF
--- a/tasks/task_10_workflow.md
+++ b/tasks/task_10_workflow.md
@@ -99,9 +99,13 @@ def grade(transcript: list, workspace_path: str) -> dict:
                 if item.get("type") == "toolCall":
                     tool_name = item.get("name", "")
                     params = item.get("params", {})
-                    if tool_name in ["read_file", "readFile"]:
+                    if tool_name.lower() in ["read_file", "readfile", "read"]:
+                        # Support multiple param formats across different agents:
+                        # - files: ["config.json"] (Cursor, Windsurf)
+                        # - path/file_path: "config.json" (OpenClaw, Claude Code)
                         files = params.get("files", [])
-                        if any("config.json" in str(f) for f in files):
+                        path_val = str(params.get("path", params.get("file_path", "")))
+                        if any("config.json" in str(f) for f in files) or "config.json" in path_val:
                             read_config = True
                             break
 


### PR DESCRIPTION
## Problem

The `task_10_workflow` automated grader checks whether the agent used a file-reading tool to read `config.json` via the `read_config` criterion. Currently it only recognizes two tool name variants:

- `read_file`
- `readFile`

And only checks the `files` parameter for the filename.

**OpenClaw** and **Claude Code** record file reads with:
- Tool name: `read` or `Read`
- Parameters: `path` or `file_path` (not `files`)

This means agents running on these platforms **always score 0.0 on `read_config`** even when they correctly read config.json as the first step.

## Fix

- Case-insensitive tool name matching: accepts `read_file`, `readfile`, `read` (covers Cursor, Windsurf, OpenClaw, Claude Code)
- Also checks `path` and `file_path` params alongside `files`

## Impact

This only affects `task_10_workflow` automated scoring. No other tasks are impacted. The fix is backward-compatible — existing tool names still match.