### PR TITLE
fix: clean OpenClaw template files from judge workspace to prevent grading failures

### DIFF
--- a/scripts/lib_grading.py
+++ b/scripts/lib_grading.py
@@ -296,8 +296,38 @@ def _ensure_judge_agent(judge_agent_prefix: str, judge_model: str, skill_dir: Pa
     model_slug = slugify_model(judge_model)
     agent_id = f"{judge_agent_prefix}-{model_slug}"
     workspace = Path("/tmp/pinchbench/judge/workspace")
-    ensure_agent_exists(agent_id, judge_model, workspace)
+    created = ensure_agent_exists(agent_id, judge_model, workspace)
+    # OpenClaw `agents add` scaffolds AGENTS.md, SOUL.md, BOOTSTRAP.md, etc.
+    # into the workspace. These template files instruct the agent to perform a
+    # bootstrap / personality flow (read SOUL.md, do introductions, etc.)
+    # instead of acting as a pure grading function. Remove them so the judge
+    # only responds to the grading prompt with JSON.
+    _clean_judge_workspace(workspace)
     return agent_id
+
+
+def _clean_judge_workspace(workspace: Path) -> None:
+    """Remove OpenClaw-scaffolded template files that interfere with judge grading."""
+    import shutil
+
+    template_files = (
+        "AGENTS.md", "SOUL.md", "BOOTSTRAP.md", "HEARTBEAT.md",
+        "IDENTITY.md", "TOOLS.md", "USER.md", "MEMORY.md",
+    )
+    template_dirs = (".git", "memory")
+    removed = 0
+    for name in template_files:
+        p = workspace / name
+        if p.exists():
+            p.unlink()
+            removed += 1
+    for name in template_dirs:
+        d = workspace / name
+        if d.is_dir():
+            shutil.rmtree(d, ignore_errors=True)
+            removed += 1
+    if removed:
+        logger.info("Cleaned %d template files/dirs from judge workspace", removed)
 
 
 def _parse_judge_response(transcript: List[Dict[str, Any]]) -> Dict[str, Any]:


### PR DESCRIPTION
## Problem

When `openclaw agents add` creates the judge agent, it scaffolds `AGENTS.md`, `SOUL.md`, `BOOTSTRAP.md` and other template files into the workspace. These files instruct the agent to perform a bootstrap/personality flow (read SOUL.md, introduce itself, etc.) before processing any prompt.

This causes the **judge agent to ignore the grading prompt entirely** and output bootstrap text like `I'm Claw 🦾, bootstrap complete...` instead of the expected JSON scores. The JSON parser then fails with `Failed to parse judge JSON response`, giving **0 scores to all `llm_judge` and `hybrid` tasks** — regardless of how well the tested model actually performed.

## Impact

In our testing with `doubao-seed-2.0-pro`:
- **13 out of 23 tasks** were affected (7 pure `llm_judge` + 6 `hybrid`)
- Reported score: **40%** (9.19/23)
- Estimated actual score: **70%+** (after excluding judge failures)
- All affected tasks had `breakdown: {}` and `notes: ""` — the judge never evaluated them

## Root Cause

```
openclaw agents add judge-agent
→ scaffolds AGENTS.md, SOUL.md, BOOTSTRAP.md into workspace
→ AGENTS.md says: "Before doing anything, read SOUL.md, USER.md..."
→ Judge receives grading prompt but executes bootstrap flow instead
→ Outputs personality text, not JSON
→ _parse_judge_response finds no JSON → returns {}
→ score = 0.0 for all judge-graded tasks
```

Note: `prepare_task_workspace` (for the tested agent) does `shutil.rmtree` before each task, so the tested agent is unaffected. Only the judge workspace persists these template files.

## Fix

Add `_clean_judge_workspace()` that removes OpenClaw-scaffolded template files (`AGENTS.md`, `SOUL.md`, `BOOTSTRAP.md`, etc.) after agent creation, ensuring the judge operates as a pure grading function.

The cleanup runs on every `_ensure_judge_agent` call (idempotent), so it also handles cases where the agent already exists but the workspace was previously polluted.

## Testing

- Verified that after cleaning template files mid-run, subsequent `llm_judge` tasks received proper JSON scores
- The fix is backward-compatible — if the workspace is already clean, it's a no-op