### PR TITLE
fix: normalize model slug to lowercase for agent/session paths

### DIFF
--- a/scripts/lib_agent.py
+++ b/scripts/lib_agent.py
@@ -20,7 +20,7 @@ MAX_OPENCLAW_MESSAGE_CHARS = int(os.environ.get("PINCHBENCH_MAX_MSG_CHARS", "400
 
 
 def slugify_model(model_id: str) -> str:
-    return model_id.replace("/", "-").replace(".", "-")
+    return model_id.replace("/", "-").replace(".", "-").lower()
 
 
 


### PR DESCRIPTION
## Problem

When running PinchBench with model IDs containing uppercase letters (e.g. `minimax/MiniMax-M2.7`), task grading can fail with transcript lookup errors:

- `Could not find agent workspace, using fallback`
- `Transcript not found — sessions dir does not exist: /root/.openclaw/agents/bench-minimax-MiniMax-M2-7/sessions`

This causes false negatives like `task_00_sanity: 0.0/1.0` even when the agent itself may have run.

## Root Cause

`slugify_model()` preserved original case, while OpenClaw agent storage paths are effectively normalized to lowercase in practice.
Result: agent/session lookup used a mixed-case path that did not match actual on-disk agent/session paths.

## Fix

Normalize slug output to lowercase in `scripts/lib_agent.py`:

```python
def slugify_model(model_id: str) -> str:
return model_id.replace("/", "-").replace(".", "-").lower()
```

## Validation
Reproduced failure with minimax/MiniMax-M2.7.
After patch, agent ID/path resolution is consistent.
Transcript lookup no longer points to non-existent mixed-case directories.

## Impact
Fixes transcript/session path mismatches for mixed-case model IDs.
Prevents false task failures caused by path mismatch rather than model behavior.