### PR TITLE
Normalize judge totals to 0-1 scale

### DIFF
--- a/scripts/lib_grading.py
+++ b/scripts/lib_grading.py
@@ -286,7 +286,8 @@ def _build_judge_prompt(task: Task, transcript_summary: str, rubric: str) -> str
         f"{transcript_summary}\n\n"
         "## Grading Rubric\n"
         f"{rubric}\n\n"
-        "Score each criterion from 0.0 to 1.0.\n\n"
+        "Score each criterion from 0.0 to 1.0.\n"
+        'The "total" field must also be between 0.0 and 1.0, and it must be the arithmetic mean of the criterion scores, not their sum.\n\n'
         "Respond with ONLY this JSON structure (no markdown, no code fences, no extra text):\n"
         '{"scores": {"criterion_name": 0.0}, "total": 0.0, "notes": "brief justification"}'
     )
@@ -428,6 +429,17 @@ def _normalize_judge_response(parsed: Dict[str, Any]) -> Dict[str, Any]:
         values = [v for v in result["scores"].values() if isinstance(v, (int, float))]
         if values:
             result["total"] = sum(values) / len(values)
+
+    # Some judge models return a summed total across criteria even though each
+    # criterion is scored on a 0..1 scale. Normalize that back to a 0..1 mean.
+    values = [v for v in result["scores"].values() if isinstance(v, (int, float))]
+    if (
+        values
+        and result["total"] is not None
+        and result["total"] > 1.0
+        and all(0.0 <= float(v) <= 1.0 for v in values)
+    ):
+        result["total"] = sum(values) / len(values)
     
     # Extract notes/justification
     if "notes" in parsed:

--- a/tests/test_lib_grading.py
+++ b/tests/test_lib_grading.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from lib_grading import _combine_grades, _normalize_judge_response, GradeResult
+
+
+class JudgeNormalizationTests(unittest.TestCase):
+    def test_normalize_judge_response_averages_summed_total_when_breakdown_is_unit_scale(
+        self,
+    ) -> None:
+        parsed = {
+            "scores": {
+                "coverage": 0.75,
+                "synthesis": 0.75,
+                "structure": 0.75,
+                "tone": 0.8,
+                "conciseness": 0.8,
+            },
+            "total": 3.85,
+            "notes": "Summed by mistake",
+        }
+
+        normalized = _normalize_judge_response(parsed)
+
+        self.assertAlmostEqual(normalized["total"], 0.77)
+
+    def test_hybrid_score_uses_normalized_judge_total(self) -> None:
+        auto = GradeResult(
+            task_id="task_16_email_triage",
+            score=0.7062937062937062,
+            max_score=1.0,
+            grading_type="automated",
+            breakdown={},
+            notes="",
+        )
+        judge = GradeResult(
+            task_id="task_16_email_triage",
+            score=0.87,
+            max_score=1.0,
+            grading_type="llm_judge",
+            breakdown={},
+            notes="",
+        )
+
+        class _Task:
+            task_id = "task_16_email_triage"
+            grading_weights = {"automated": 0.4, "llm_judge": 0.6}
+
+        combined = _combine_grades(_Task(), auto, judge)
+
+        self.assertAlmostEqual(combined.score, 0.8045174825174824)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

  This fixes an issue where LLM-judge scores could exceed `1.0` when the judge returned a `total` that was the sum of per-criterion scores instead of
  their mean.

  The grading pipeline already expects scores on a `0..1` scale, but some recent runs showed impossible values like `3.85/1.0`, `5.0/1.0`, and hybrid
  scores above `1.0`.

  ## What changed

  - Clarified the judge prompt so `total` must be the arithmetic mean of criterion scores and must remain in `0..1`
  - Normalized judge responses so that when:
    - per-criterion scores are in `0..1`, and
    - the returned `total` is greater than `1.0`

    we treat that total as a summed score and convert it back to the mean
  - Added regression tests for:
    - summed LLM-judge totals being normalized back to `0..1`
    - hybrid scoring staying within range after normalization

  ## Evidence

  Observed in saved benchmark runs:

  - `results/0009_local-openai-gpt-oss-20b.json`
    - `task_15_daily_summary`: `3.85/1.0`
    - `task_16_email_triage`: `2.8925/1.0`
  - `results/0010_local-openai-gpt-oss-20b.json`
    - `task_15_daily_summary`: `5.0/1.0`
    - `task_17_email_search`: `3.39/1.0`

  In these cases, the criterion breakdowns were already on a `0..1` scale, so the overflowing totals were consistent with summed judge outputs leaking
  into aggregate scoring.

  ## Validation

  ```bash
  python3 -m py_compile scripts/lib_grading.py tests/test_lib_grading.py
  python3 -m unittest tests/test_lib_grading.py