### PR TITLE
  Fix lib_agent indentation regression

### DIFF
--- a/scripts/lib_agent.py
+++ b/scripts/lib_agent.py
@@ -367,13 +367,11 @@ def prepare_task_workspace(skill_dir: Path, run_id: str, task: Task, agent_id: s
     _BOOTSTRAP_FILES = ["SOUL.md", "BOOTSTRAP.md", "USER.md", "IDENTITY.md", "HEARTBEAT.md", "TOOLS.md"]
 
     def _remove_readonly(func, path, _):
-    def _remove_readonly(func, path, _):
         try:
             os.chmod(path, stat.S_IWRITE)
             func(path)
         except OSError:
             pass
-        func(path)
 
     saved_bootstrap: dict[str, bytes] = {}
     if workspace.exists():


### PR DESCRIPTION
Fix a merge regression in `scripts/lib_agent.py`.

`_remove_readonly()` was duplicated and left with a stray misindented line, which causes:

```bash
python3 -m py_compile scripts/lib_agent.py
```

to fail with IndentationError.

This PR removes the duplicate definition and restores valid syntax.
