### PR TITLE
Fix duplicate _remove_readonly causing IndentationError

### DIFF
--- a/scripts/lib_agent.py
+++ b/scripts/lib_agent.py
@@ -367,13 +367,11 @@ def prepare_task_workspace(skill_dir: Path, run_id: str, task: Task, agent_id: s
     _BOOTSTRAP_FILES = ["SOUL.md", "BOOTSTRAP.md", "USER.md", "IDENTITY.md", "HEARTBEAT.md", "TOOLS.md"]
 
     def _remove_readonly(func, path, _):
-    def _remove_readonly(func, path, _):
         try:
             os.chmod(path, stat.S_IWRITE)
             func(path)
         except OSError:
             pass
-        func(path)
 
     saved_bootstrap: dict[str, bytes] = {}
     if workspace.exists():


### PR DESCRIPTION
## Summary
- Remove duplicate `def _remove_readonly` line that causes `IndentationError` on import
- Remove extra bare `func(path)` call outside the try/except block

The first definition had no body, causing a syntax error that prevents `lib_agent.py` from loading.