### PR TITLE
Fix judge API: use max_completion_tokens for OpenAI/OpenRouter

### DIFF
--- a/scripts/lib_agent.py
+++ b/scripts/lib_agent.py
@@ -1084,7 +1084,7 @@ def _judge_via_openai_compat(
             {"role": "user", "content": prompt},
         ],
         "temperature": 0.0,
-        "max_tokens": 2048,
+        "max_completion_tokens": 2048,
     }).encode("utf-8")
 
     headers = {


### PR DESCRIPTION
## Summary

- Newer OpenAI models (gpt-5.4-mini, etc.) reject the deprecated `max_tokens` parameter with HTTP 400
- Use `max_completion_tokens` for the OpenAI-compatible judge endpoint (used by both OpenAI and OpenRouter)
- Anthropic endpoint keeps `max_tokens` as required by their API

## Test plan

- [x] Tested with `--judge openai/gpt-5.4-mini`