### PR TITLE
Add GWS-powered tasks using fws mock server

### DIFF
--- a/scripts/lib_agent.py
+++ b/scripts/lib_agent.py
@@ -750,6 +750,9 @@ def execute_openclaw_task(
         else:
             fws_env = start_fws()
 
+    # Use --local for fws tasks so env vars propagate to the agent
+    use_local = fws_env is not None
+
     start_time = time.time()
     workspace = prepare_task_workspace(skill_dir, run_id, task, agent_id)
     session_id = f"{task.task_id}_{int(time.time() * 1000)}"
@@ -781,8 +784,7 @@ def execute_openclaw_task(
                 timed_out = True
                 break
             try:
-                result = subprocess.run(
-                    [
+                cmd = [
                         "openclaw",
                         "agent",
                         "--agent",
@@ -791,13 +793,17 @@ def execute_openclaw_task(
                         session_id,
                         "--message",
                         session_prompt,
-                    ],
+                    ]
+                if use_local:
+                    cmd.insert(2, "--local")
+                result = subprocess.run(
+                    cmd,
                     capture_output=True,
                     text=True,
                     cwd=str(workspace),
                     timeout=remaining,
                     check=False,
-            shell=USE_SHELL,
+                    shell=USE_SHELL,
                 )
                 stdout += result.stdout
                 stderr += result.stderr
@@ -815,8 +821,7 @@ def execute_openclaw_task(
     else:
         # Single-session task: send task.prompt once
         try:
-            result = subprocess.run(
-                [
+            cmd = [
                     "openclaw",
                     "agent",
                     "--agent",
@@ -825,13 +830,17 @@ def execute_openclaw_task(
                     session_id,
                     "--message",
                     task.prompt,
-                ],
+                ]
+            if use_local:
+                cmd.insert(2, "--local")
+            result = subprocess.run(
+                cmd,
                 capture_output=True,
                 text=True,
                 cwd=str(workspace),
                 timeout=timeout_seconds,
                 check=False,
-            shell=USE_SHELL,
+                shell=USE_SHELL,
             )
             stdout = result.stdout
             stderr = result.stderr

--- a/scripts/lib_agent.py
+++ b/scripts/lib_agent.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 from urllib import error, request
 
 from lib_tasks import Task
+from lib_fws import is_fws_task, fws_available, start_fws, stop_fws
 
 
 logger = logging.getLogger(__name__)
@@ -741,6 +742,14 @@ def execute_openclaw_task(
     # transcript (OpenClaw uses its own UUID-based naming, not our session ID).
     cleanup_agent_sessions(agent_id)
 
+    # Start fws server for GWS tasks
+    fws_env = None
+    if is_fws_task(task.frontmatter):
+        if not fws_available():
+            logger.warning("⚠️ Task %s requires fws but it's not installed (npm install -g @juppytt/fws)", task.task_id)
+        else:
+            fws_env = start_fws()
+
     start_time = time.time()
     workspace = prepare_task_workspace(skill_dir, run_id, task, agent_id)
     session_id = f"{task.task_id}_{int(time.time() * 1000)}"
@@ -894,6 +903,10 @@ def execute_openclaw_task(
                         logger.info("      %s (%d bytes)", f.relative_to(workspace), size)
                     except OSError:
                         logger.info("      %s", f.relative_to(workspace))
+
+    # Stop fws mock server if we started it
+    if fws_env is not None:
+        stop_fws(fws_env)
 
     return {
         "agent_id": agent_id,
@@ -1084,7 +1097,7 @@ def _judge_via_openai_compat(
             {"role": "user", "content": prompt},
         ],
         "temperature": 0.0,
-        "max_tokens": 2048,
+        "max_completion_tokens": 2048,
     }).encode("utf-8")
 
     headers = {

--- a/scripts/lib_fws.py
+++ b/scripts/lib_fws.py
@@ -1,0 +1,105 @@
+"""
+fws lifecycle management for GWS-based tasks.
+
+Starts/stops the fws server and configures environment variables
+so that gws CLI commands are redirected to the local mock.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+
+logger = logging.getLogger("pinchbench")
+
+# Environment variables that fws sets
+MOCK_GWS_ENV_KEYS = [
+    "GOOGLE_WORKSPACE_CLI_CONFIG_DIR",
+    "GOOGLE_WORKSPACE_CLI_TOKEN",
+    "HTTPS_PROXY",
+    "SSL_CERT_FILE",
+]
+
+
+def is_fws_task(frontmatter: dict) -> bool:
+    """Check if a task requires fws (category is gws/github or prerequisites include fws)."""
+    if frontmatter.get("category") in ("gws", "github"):
+        return True
+    prereqs = frontmatter.get("prerequisites", [])
+    return any("fws" in str(p) for p in prereqs)
+
+
+def fws_available() -> bool:
+    """Check if fws CLI is available."""
+    return shutil.which("fws") is not None
+
+
+def start_fws() -> dict:
+    """Start the fws server and set environment variables.
+
+    Returns a dict of the original env var values (for restoration).
+    """
+    logger.info("🔧 Starting fws server...")
+
+    # Stop any existing server
+    subprocess.run(["fws", "server", "stop"], capture_output=True, check=False)
+    time.sleep(0.3)
+
+    # Start server
+    result = subprocess.run(
+        ["fws", "server", "start"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        logger.error("Failed to start fws: %s", result.stderr)
+        raise RuntimeError(f"fws server start failed: {result.stderr}")
+
+    # Parse the env vars from output
+    env_vars = {}
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("export "):
+            line = line[7:]
+        if "=" in line and any(key in line for key in MOCK_GWS_ENV_KEYS):
+            key, _, value = line.partition("=")
+            env_vars[key.strip()] = value.strip()
+
+    if not env_vars:
+        # Fallback: use default paths
+        home = os.path.expanduser("~")
+        env_vars = {
+            "GOOGLE_WORKSPACE_CLI_CONFIG_DIR": f"{home}/.local/share/fws/config",
+            "GOOGLE_WORKSPACE_CLI_TOKEN": "fake",
+            "HTTPS_PROXY": "http://localhost:4101",
+            "SSL_CERT_FILE": f"{home}/.local/share/fws/certs/ca.crt",
+        }
+
+    # Save original values and set new ones
+    original_env = {}
+    for key, value in env_vars.items():
+        original_env[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    logger.info("✅ fws server started, env configured")
+    return original_env
+
+
+def stop_fws(original_env: dict) -> None:
+    """Stop the fws server and restore original environment variables."""
+    logger.info("🔧 Stopping fws server...")
+
+    subprocess.run(["fws", "server", "stop"], capture_output=True, check=False)
+
+    # Restore original env
+    for key, value in original_env.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+    logger.info("✅ fws server stopped, env restored")

--- a/tasks/task_26_gws_email_triage.md
+++ b/tasks/task_26_gws_email_triage.md
@@ -1,0 +1,149 @@
+---
+id: task_26_gws_email_triage
+name: GWS Email Triage
+category: gws
+grading_type: hybrid
+timeout_seconds: 300
+grading_weights:
+  automated: 0.5
+  llm_judge: 0.5
+workspace_files: []
+prerequisites:
+  - npm:@juppytt/fws
+  - cli:gws
+---
+
+## Prompt
+
+You have access to a Google Workspace account through the `gws` CLI tool (`gws --help` for usage).
+
+Your inbox has several unread emails. Triage them:
+
+1. Check your unread emails
+2. Read each message to understand its content and urgency
+3. For the most urgent email, draft a reply (save as draft, don't send)
+4. Create a triage report saved to `triage_report.md` with priority (P0-P3), category, and recommended action for each email, sorted by priority (most urgent first)
+
+## Expected Behavior
+
+The agent should:
+
+1. Discover and use gws Gmail commands to list and read emails
+2. Analyze message content, sender, and urgency
+3. Identify the most urgent email and create a draft reply
+4. Write a structured triage report to `triage_report.md`
+
+This tests the agent's ability to discover and use the gws CLI for a multi-step email workflow: list, read, draft, and synthesize.
+
+## Grading Criteria
+
+- [ ] Agent listed unread emails using gws
+- [ ] Agent read individual messages using gws
+- [ ] Agent created a draft reply for the most urgent email
+- [ ] File `triage_report.md` created in workspace
+- [ ] All unread messages are present in the report
+- [ ] Each message has a priority assigned (P0-P3)
+- [ ] Each message has a recommended action
+- [ ] Report is sorted by priority
+
+## Automated Checks
+
+```python
+def grade(transcript: list, workspace_path: str) -> dict:
+    """
+    Grade the GWS email triage task.
+    """
+    from pathlib import Path
+    import re
+
+    scores = {}
+    workspace = Path(workspace_path)
+
+    used_list = False
+    used_get = False
+    used_draft = False
+
+    def extract_commands(transcript):
+        """Extract shell commands from transcript, handling multiple tool call formats."""
+        cmds = []
+        for event in transcript:
+            if event.get("type") != "message":
+                continue
+            msg = event.get("message", {})
+            for item in msg.get("content", []):
+                t = item.get("type", "")
+                if t in ("tool_use", "toolCall"):
+                    cmd = (
+                        item.get("input", {}).get("command", "")
+                        or item.get("arguments", {}).get("command", "")
+                        or item.get("params", {}).get("command", "")
+                    )
+                    if cmd:
+                        cmds.append(cmd)
+        return cmds
+
+    for cmd in extract_commands(transcript):
+        if "gws" in cmd and ("triage" in cmd or "messages list" in cmd):
+            used_list = True
+        if "gws" in cmd and "messages get" in cmd:
+            used_get = True
+        if "gws" in cmd and "drafts create" in cmd:
+            used_draft = True
+
+    scores["listed_emails"] = 1.0 if used_list else 0.0
+    scores["read_messages"] = 1.0 if used_get else 0.0
+    scores["created_draft"] = 1.0 if used_draft else 0.0
+
+    report_file = workspace / "triage_report.md"
+    if report_file.exists():
+        scores["report_created"] = 1.0
+        content = report_file.read_text().lower()
+
+        has_priorities = bool(re.search(r'p[0-3]', content))
+        scores["priorities_assigned"] = 1.0 if has_priorities else 0.0
+
+        p0_pos = content.find("p0")
+        p3_pos = content.find("p3")
+        if p0_pos >= 0 and p3_pos >= 0:
+            scores["sorted_by_priority"] = 1.0 if p0_pos < p3_pos else 0.0
+        else:
+            scores["sorted_by_priority"] = 0.5
+    else:
+        scores["report_created"] = 0.0
+        scores["priorities_assigned"] = 0.0
+        scores["sorted_by_priority"] = 0.0
+
+    return scores
+```
+
+## LLM Judge Rubric
+
+### Criterion 1: GWS CLI Discovery and Usage (Weight: 30%)
+
+**Score 1.0**: Agent discovered and fluently used gws Gmail commands (list, get, drafts) with correct parameters.
+**Score 0.75**: Agent used the gws CLI correctly but with minor parameter issues or extra unnecessary calls.
+**Score 0.5**: Agent used some gws commands but struggled with syntax or missed key commands.
+**Score 0.25**: Agent barely used gws CLI or used incorrect commands.
+**Score 0.0**: Agent did not use gws CLI at all.
+
+### Criterion 2: Triage Quality (Weight: 40%)
+
+**Score 1.0**: All emails correctly prioritized with accurate categories and specific, actionable recommendations.
+**Score 0.75**: Most emails correctly prioritized with minor misclassifications. Recommendations are reasonable.
+**Score 0.5**: Some emails correctly prioritized but notable errors in judgment. Recommendations are generic.
+**Score 0.25**: Priority assignments are mostly incorrect or missing.
+**Score 0.0**: No meaningful triage performed.
+
+### Criterion 3: Draft Reply Quality (Weight: 30%)
+
+**Score 1.0**: Draft reply targets the correct urgent email with a professional response that acknowledges the situation.
+**Score 0.75**: Draft targets the right email with a reasonable response, but tone or content could be improved.
+**Score 0.5**: Draft created but targets a less appropriate email, or content is generic.
+**Score 0.25**: Draft created but with incorrect format or irrelevant content.
+**Score 0.0**: No draft created.
+
+## Additional Notes
+
+This task requires [fws](https://github.com/juppytt/fws) to be running as a mock GWS server. The test runner should execute `fws server start` before the task begins and set environment variables (GOOGLE_WORKSPACE_CLI_CONFIG_DIR, GOOGLE_WORKSPACE_CLI_TOKEN, HTTPS_PROXY, SSL_CERT_FILE).
+
+The fws seed data includes 5 emails: 3 unread inbox messages (from alice@company.com about Q3 Planning, bob@company.com about a code review, notifications@github.com about a CI failure), 1 sent message, and 1 read message.

--- a/tasks/task_27_gws_cross_service.md
+++ b/tasks/task_27_gws_cross_service.md
@@ -1,0 +1,132 @@
+---
+id: task_27_gws_cross_service
+name: GWS Cross-Service Workflow
+category: gws
+grading_type: hybrid
+timeout_seconds: 300
+grading_weights:
+  automated: 0.6
+  llm_judge: 0.4
+workspace_files: []
+prerequisites:
+  - npm:@juppytt/fws
+  - cli:gws
+---
+
+## Prompt
+
+You have access to a Google Workspace account through the `gws` CLI tool (`gws --help` for usage).
+
+You received an email from alice@company.com about a "Q3 Planning Meeting". Do the following:
+
+1. Find and read that email to get the meeting details
+2. Create a calendar event for the meeting based on what you find in the email
+3. Find the "Q3 Planning Agenda" document in Drive and share it with bob@company.com (reader access)
+4. Save a summary of what you did to `actions.md`
+
+## Expected Behavior
+
+The agent should:
+
+1. Search or list Gmail messages to find the Q3 Planning email from Alice
+2. Read the email content for meeting details
+3. Use gws Calendar to create an event with the correct summary, time, and attendees
+4. Use gws Drive to find the agenda document and add a permission for bob@company.com
+5. Write a summary of completed actions to `actions.md`
+
+This tests the agent's ability to coordinate across Gmail, Calendar, and Drive in a single workflow.
+
+## Grading Criteria
+
+- [ ] Agent found and read the Q3 Planning email
+- [ ] Calendar event created with relevant summary
+- [ ] Calendar event has a start time
+- [ ] Q3 Planning Agenda document found in Drive
+- [ ] Permission created on the document for bob@company.com
+- [ ] File `actions.md` created with a summary of actions taken
+
+## Automated Checks
+
+```python
+def grade(transcript: list, workspace_path: str) -> dict:
+    """
+    Grade the GWS cross-service workflow task.
+    """
+    from pathlib import Path
+
+    scores = {}
+    workspace = Path(workspace_path)
+
+    read_email = False
+    created_event = False
+    found_file = False
+    shared_file = False
+
+    def extract_commands(transcript):
+        """Extract shell commands from transcript, handling multiple tool call formats."""
+        cmds = []
+        for event in transcript:
+            if event.get("type") != "message":
+                continue
+            msg = event.get("message", {})
+            for item in msg.get("content", []):
+                t = item.get("type", "")
+                if t in ("tool_use", "toolCall"):
+                    cmd = (
+                        item.get("input", {}).get("command", "")
+                        or item.get("arguments", {}).get("command", "")
+                        or item.get("params", {}).get("command", "")
+                    )
+                    if cmd:
+                        cmds.append(cmd)
+        return cmds
+
+    for cmd in extract_commands(transcript):
+        if "gws" not in cmd:
+            continue
+        if "messages get" in cmd or "messages list" in cmd or "+triage" in cmd:
+            read_email = True
+        if "events insert" in cmd or "events create" in cmd:
+            created_event = True
+        if "files list" in cmd or "files get" in cmd:
+            found_file = True
+        if "permissions create" in cmd:
+            shared_file = True
+
+    scores["read_email"] = 1.0 if read_email else 0.0
+    scores["created_event"] = 1.0 if created_event else 0.0
+    scores["found_drive_file"] = 1.0 if found_file else 0.0
+    scores["shared_file"] = 1.0 if shared_file else 0.0
+
+    actions_file = workspace / "actions.md"
+    if actions_file.exists():
+        scores["actions_summary"] = 1.0
+    else:
+        scores["actions_summary"] = 0.0
+
+    return scores
+```
+
+## LLM Judge Rubric
+
+### Criterion 1: Cross-Service Coordination (Weight: 50%)
+
+**Score 1.0**: Agent seamlessly navigated Gmail, Calendar, and Drive, extracting information from one service and using it in another. The workflow was logical and efficient.
+**Score 0.75**: Agent used all three services but with minor inefficiencies or missed connections between them.
+**Score 0.5**: Agent used two of three services correctly but failed to connect data between them.
+**Score 0.25**: Agent attempted to use the services but struggled with most operations.
+**Score 0.0**: Agent failed to use gws across multiple services.
+
+### Criterion 2: Task Completeness (Weight: 50%)
+
+**Score 1.0**: All four steps completed correctly: email read, event created with correct details, document shared with bob, summary written.
+**Score 0.75**: Three of four steps completed correctly.
+**Score 0.5**: Two of four steps completed correctly.
+**Score 0.25**: One step completed correctly.
+**Score 0.0**: No steps completed.
+
+## Additional Notes
+
+This task requires [fws](https://github.com/juppytt/fws) to be running as a mock GWS server. The test runner should execute `fws server start` before the task begins and set environment variables (GOOGLE_WORKSPACE_CLI_CONFIG_DIR, GOOGLE_WORKSPACE_CLI_TOKEN, HTTPS_PROXY, SSL_CERT_FILE).
+
+fws seed data includes: an email from alice@company.com about "Q3 Planning Meeting", a Drive file named "Q3 Planning Agenda" (id: file001), and a primary calendar with existing events.

--- a/tasks/task_28_gws_task_management.md
+++ b/tasks/task_28_gws_task_management.md
@@ -1,0 +1,139 @@
+---
+id: task_28_gws_task_management
+name: GWS Task Management
+category: gws
+grading_type: hybrid
+timeout_seconds: 300
+grading_weights:
+  automated: 0.6
+  llm_judge: 0.4
+workspace_files: []
+prerequisites:
+  - npm:@juppytt/fws
+  - cli:gws
+---
+
+## Prompt
+
+You have access to a Google Workspace account through the `gws` CLI tool (`gws --help` for usage).
+
+Manage your tasks based on what's in your inbox:
+
+1. Check your current task list and mark any already-completed items as done
+2. Read your recent emails to find action items
+3. Create a new task for each action item you find in the emails
+4. Save a summary to `task_summary.md` listing what tasks you found, created, and completed
+
+## Expected Behavior
+
+The agent should:
+
+1. Use gws Tasks to list current tasks and update completed ones
+2. Use gws Gmail to read recent messages and extract action items
+3. Create new tasks from the action items found in emails
+4. Write a summary to `task_summary.md`
+
+This tests the agent's ability to combine Tasks and Gmail, extract structured information from unstructured email content, and manage a task list.
+
+## Grading Criteria
+
+- [ ] Agent listed existing tasks using gws
+- [ ] Agent marked completed task(s) as done
+- [ ] Agent read emails using gws
+- [ ] At least one new task created from email action items
+- [ ] New tasks have meaningful titles derived from email content
+- [ ] File `task_summary.md` created with a summary
+
+## Automated Checks
+
+```python
+def grade(transcript: list, workspace_path: str) -> dict:
+    """
+    Grade the GWS task management task.
+    """
+    from pathlib import Path
+
+    scores = {}
+    workspace = Path(workspace_path)
+
+    listed_tasks = False
+    updated_task = False
+    read_emails = False
+    created_task = False
+
+    def extract_commands(transcript):
+        """Extract shell commands from transcript, handling multiple tool call formats."""
+        cmds = []
+        for event in transcript:
+            if event.get("type") != "message":
+                continue
+            msg = event.get("message", {})
+            for item in msg.get("content", []):
+                t = item.get("type", "")
+                if t in ("tool_use", "toolCall"):
+                    cmd = (
+                        item.get("input", {}).get("command", "")
+                        or item.get("arguments", {}).get("command", "")
+                        or item.get("params", {}).get("command", "")
+                    )
+                    if cmd:
+                        cmds.append(cmd)
+        return cmds
+
+    for cmd in extract_commands(transcript):
+        if "gws" not in cmd:
+            continue
+        if "tasks" in cmd and "list" in cmd:
+            listed_tasks = True
+        if "tasks" in cmd and ("patch" in cmd or "update" in cmd):
+            updated_task = True
+        if "gmail" in cmd and ("messages" in cmd or "triage" in cmd):
+            read_emails = True
+        if "tasks" in cmd and "insert" in cmd:
+            created_task = True
+
+    scores["listed_tasks"] = 1.0 if listed_tasks else 0.0
+    scores["updated_completed"] = 1.0 if updated_task else 0.0
+    scores["read_emails"] = 1.0 if read_emails else 0.0
+    scores["created_new_task"] = 1.0 if created_task else 0.0
+
+    summary_file = workspace / "task_summary.md"
+    if summary_file.exists():
+        scores["summary_created"] = 1.0
+    else:
+        scores["summary_created"] = 0.0
+
+    return scores
+```
+
+## LLM Judge Rubric
+
+### Criterion 1: Information Extraction (Weight: 40%)
+
+**Score 1.0**: Agent correctly identified actionable items from emails and created well-titled, specific tasks for each.
+**Score 0.75**: Agent found most action items with reasonable task titles.
+**Score 0.5**: Agent found some action items but missed important ones, or task titles are vague.
+**Score 0.25**: Agent created tasks but they don't clearly relate to email content.
+**Score 0.0**: No tasks created from emails.
+
+### Criterion 2: Task List Management (Weight: 30%)
+
+**Score 1.0**: Agent correctly reviewed existing tasks, identified the completed one, marked it done, and organized new tasks logically.
+**Score 0.75**: Agent managed the task list with minor oversights.
+**Score 0.5**: Agent partially managed the task list but missed updating completed tasks or had other gaps.
+**Score 0.25**: Agent interacted with tasks minimally.
+**Score 0.0**: Agent did not manage the task list.
+
+### Criterion 3: Summary Quality (Weight: 30%)
+
+**Score 1.0**: Summary clearly lists what was found, what was created, and what was completed, with good organization.
+**Score 0.75**: Summary covers the key points but could be better organized.
+**Score 0.5**: Summary exists but is incomplete or poorly structured.
+**Score 0.25**: Summary is minimal or unclear.
+**Score 0.0**: No summary created.
+
+## Additional Notes
+
+This task requires [fws](https://github.com/juppytt/fws) to be running as a mock GWS server. The test runner should execute `fws server start` before the task begins and set environment variables (GOOGLE_WORKSPACE_CLI_CONFIG_DIR, GOOGLE_WORKSPACE_CLI_TOKEN, HTTPS_PROXY, SSL_CERT_FILE).
+
+fws seed data includes: a "My Tasks" list with 2 tasks (1 pending: "Review Q3 proposal", 1 completed: "Update documentation"), and 5 emails with various action items (Q3 planning meeting, code review request, CI failure notification).

--- a/tasks/task_29_gh_issue_triage.md
+++ b/tasks/task_29_gh_issue_triage.md
@@ -1,0 +1,143 @@
+---
+id: task_29_gh_issue_triage
+name: GitHub Issue Triage
+category: github
+grading_type: hybrid
+timeout_seconds: 300
+grading_weights:
+  automated: 0.5
+  llm_judge: 0.5
+workspace_files: []
+prerequisites:
+  - npm:@juppytt/fws
+  - cli:gh
+---
+
+## Prompt
+
+You have access to a GitHub repository through the `gh` CLI tool (`gh --help` for usage). The repository is `testuser/my-project`.
+
+Review the open issues and pull requests:
+
+1. List all open issues and PRs
+2. Read each one to understand its content
+3. For the most critical issue, add a comment with your analysis and suggested next steps
+4. Create a triage report saved to `triage_report.md` with priority, category, and recommended action for each item, sorted by priority
+
+## Expected Behavior
+
+The agent should:
+
+1. Use gh CLI to list and read issues and PRs
+2. Analyze each item for urgency and impact
+3. Comment on the most critical issue
+4. Write a structured triage report to `triage_report.md`
+
+This tests the agent's ability to use the gh CLI for a multi-step GitHub workflow: list, read, comment, and synthesize.
+
+## Grading Criteria
+
+- [ ] Agent listed issues using gh
+- [ ] Agent listed or viewed PRs using gh
+- [ ] Agent read individual issues/PRs to understand content
+- [ ] Agent commented on the most critical issue
+- [ ] File `triage_report.md` created in workspace
+- [ ] All open items are present in the report
+- [ ] Each item has a priority assigned
+- [ ] Report is sorted by priority
+
+## Automated Checks
+
+```python
+def grade(transcript: list, workspace_path: str) -> dict:
+    """
+    Grade the GitHub issue triage task.
+    """
+    from pathlib import Path
+    import re
+
+    scores = {}
+    workspace = Path(workspace_path)
+
+    listed_issues = False
+    viewed_pr = False
+    read_detail = False
+    commented = False
+
+    def extract_commands(transcript):
+        cmds = []
+        for event in transcript:
+            if event.get("type") != "message":
+                continue
+            msg = event.get("message", {})
+            for item in msg.get("content", []):
+                t = item.get("type", "")
+                if t in ("tool_use", "toolCall"):
+                    cmd = (
+                        item.get("input", {}).get("command", "")
+                        or item.get("arguments", {}).get("command", "")
+                        or item.get("params", {}).get("command", "")
+                    )
+                    if cmd:
+                        cmds.append(cmd)
+        return cmds
+
+    for cmd in extract_commands(transcript):
+        if "gh" in cmd and ("issue list" in cmd or "api" in cmd and "issues" in cmd):
+            listed_issues = True
+        if "gh" in cmd and ("pr list" in cmd or "pr view" in cmd or "pulls" in cmd):
+            viewed_pr = True
+        if "gh" in cmd and ("issue view" in cmd or "issues/" in cmd):
+            read_detail = True
+        if "gh" in cmd and ("comment" in cmd or "comments" in cmd) and ("-f" in cmd or "--body" in cmd or "-X POST" in cmd):
+            commented = True
+
+    scores["listed_issues"] = 1.0 if listed_issues else 0.0
+    scores["viewed_prs"] = 1.0 if viewed_pr else 0.0
+    scores["read_detail"] = 1.0 if read_detail else 0.0
+    scores["commented"] = 1.0 if commented else 0.0
+
+    report_file = workspace / "triage_report.md"
+    if report_file.exists():
+        scores["report_created"] = 1.0
+        content = report_file.read_text().lower()
+        has_priorities = bool(re.search(r'(p[0-3]|critical|high|medium|low|urgent)', content))
+        scores["priorities_assigned"] = 1.0 if has_priorities else 0.0
+    else:
+        scores["report_created"] = 0.0
+        scores["priorities_assigned"] = 0.0
+
+    return scores
+```
+
+## LLM Judge Rubric
+
+### Criterion 1: gh CLI Usage (Weight: 30%)
+
+**Score 1.0**: Agent fluently used gh CLI to list, view, and comment on issues/PRs with correct parameters.
+**Score 0.75**: Agent used gh CLI correctly but with minor parameter issues.
+**Score 0.5**: Agent used some gh commands but struggled with syntax.
+**Score 0.25**: Agent barely used gh CLI.
+**Score 0.0**: Agent did not use gh CLI at all.
+
+### Criterion 2: Triage Quality (Weight: 40%)
+
+**Score 1.0**: All items correctly prioritized with accurate analysis and specific recommendations.
+**Score 0.75**: Most items correctly prioritized with reasonable analysis.
+**Score 0.5**: Some items prioritized but notable errors in judgment.
+**Score 0.25**: Priority assignments are mostly incorrect or missing.
+**Score 0.0**: No meaningful triage performed.
+
+### Criterion 3: Comment Quality (Weight: 30%)
+
+**Score 1.0**: Comment on the right issue with insightful analysis and actionable next steps.
+**Score 0.75**: Comment targets the right issue with reasonable suggestions.
+**Score 0.5**: Comment created but targets a less appropriate issue or is generic.
+**Score 0.25**: Comment created but with irrelevant content.
+**Score 0.0**: No comment created.
+
+## Additional Notes
+
+This task requires [fws](https://github.com/juppytt/fws) to be running as a mock server. The test runner should execute `fws server start` before the task begins and set environment variables via `eval $(fws server env)`.
+
+Seed data includes: 1 repo (testuser/my-project), 2 open issues (#1 "Fix login bug" with a comment, #2 "Add dark mode support"), and 1 open PR (#3 "Fix SSO login flow").


### PR DESCRIPTION
## Summary

Add 4 tasks that use `gws` and `gh` CLIs against [fws](https://github.com/juppytt/fws) (local mock server). Enables realistic Google Workspace and GitHub testing without OAuth.

**GWS tasks:**
- **task_26_gws_email_triage**: List unread emails, read them, draft a reply, write a triage report
- **task_27_gws_cross_service**: Read an email, create a calendar event, share a Drive document
- **task_28_gws_task_management**: Review task list, read emails for action items, create new tasks

**GitHub tasks:**
- **task_29_gh_issue_triage**: List issues/PRs, read them, comment on the most critical, write a triage report

Runner integration auto-starts/stops fws for tasks with `category: gws` or `category: github`.

## Setup

```bash
npm install -g @googleworkspace/cli   # gws CLI
npm install -g @juppytt/fws           # fws mock server
# gh CLI assumed already installed
```

## Changes

- `tasks/task_26_gws_email_triage.md` - new task
- `tasks/task_27_gws_cross_service.md` - new task
- `tasks/task_28_gws_task_management.md` - new task
- `tasks/task_29_gh_issue_triage.md` - new task
- `scripts/lib_fws.py` - fws lifecycle management (start/stop/env)
- `scripts/lib_agent.py` - auto-start fws for gws/github tasks, fix transcript parsing for toolCall/exec format, fix `max_completion_tokens` for OpenAI judge

## Test plan

- [x] Ran task_26 with `openai/gpt-5.4-mini`, agent used gws CLI correctly
- [x] fws server starts/stops correctly around task execution
- [x] Grading correctly detects gws/gh commands in transcript

Ref: #119