### PR TITLE
fix(grader): support 'arguments' key in tool calls + strip list prefixes in number extraction

### DIFF
--- a/tasks/task_10_workflow.md
+++ b/tasks/task_10_workflow.md
@@ -98,7 +98,8 @@ def grade(transcript: list, workspace_path: str) -> dict:
             for item in msg.get("content", []):
                 if item.get("type") == "toolCall":
                     tool_name = item.get("name", "")
-                    params = item.get("params", {})
+                    # Support both "params" (Cursor/Windsurf) and "arguments" (OpenClaw/Claude Code)
+                    params = item.get("params", item.get("arguments", {}))
                     if tool_name.lower() in ["read_file", "readfile", "read"]:
                         # Support multiple param formats across different agents:
                         # - files: ["config.json"] (Cursor, Windsurf)

--- a/tasks/task_21_openclaw_comprehension.md
+++ b/tasks/task_21_openclaw_comprehension.md
@@ -77,9 +77,13 @@ def grade(transcript: list, workspace_path: str) -> dict:
     lines = [l.strip() for l in content.splitlines() if l.strip()]
     full_text = content.lower()
 
-    # Helper to extract numbers from text
+    # Helper to extract numbers from text.
+    # Strips leading list markers ("1. ", "2) ", etc.) so that agents which
+    # number their answers ("1. 5705") don't have the line prefix returned
+    # instead of the actual value.
     def extract_number(text):
-        numbers = re.findall(r'[\d,]+', text)
+        cleaned = re.sub(r'^\s*\d+[.)]\s+', '', text)
+        numbers = re.findall(r'[\d,]+', cleaned)
         for n in numbers:
             val = int(n.replace(',', ''))
             if val > 0:


### PR DESCRIPTION
## Summary

Two grader bugs found while running kimi-k2p5-fireworks (Fireworks AI) against the full PinchBench suite.

---

### Fix 1: `arguments` key not recognized in tool call params (task_10_workflow)

**Problem:** The `read_config` check scanned `item.get("params", {})` for tool call arguments. OpenClaw and Claude Code serialize these under `"arguments"` not `"params"`. Any agent using these frameworks always scored 0 on this check even when the file was correctly read.

**Fix:** Fall back to `"arguments"` when `"params"` is absent:
```python
# Before
params = item.get("params", {})

# After
params = item.get("params", item.get("arguments", {}))
```

The grader comment already listed OpenClaw and Claude Code as supported agents — this makes it actually work for them.

---

### Fix 2: List-prefixed answers break number extraction (task_21_openclaw_comprehension)

**Problem:** `extract_number()` returned the first number found in a line. Agents that prefix answers with list markers (`"1. 5705"`, `"2. 2999"`) had the prefix digit returned instead of the actual answer, causing correct values to score 0.0.

**Fix:** Strip leading list markers before scanning:
```python
# Before
numbers = re.findall(r'[\d,]+', text)

# After
cleaned = re.sub(r'^\s*\d+[.)]\s+', '', text)
numbers = re.findall(r'[\d,]+', cleaned)
```

Plain answers (`"5705"`) are unaffected. Numbered answers (`"1. 5705"`) now correctly extract `5705`.

**Observed:** kimi-k2p5 wrote `"1. 5705"` and `"2. 2999"` — correct values, 0.0 score.

---

## Verified against

Full 32-task run of kimi-k2p5-fireworks on OpenClaw with claude-opus-4-6 as judge. Both fixes confirmed against real transcripts from the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)