### PR TITLE
fix(grader): support 'arguments' key for tool calls in task_workflow

### DIFF
--- a/tasks/task_workflow.md
+++ b/tasks/task_workflow.md
@@ -98,7 +98,8 @@ def grade(transcript: list, workspace_path: str) -> dict:
             for item in msg.get("content", []):
                 if item.get("type") == "toolCall":
                     tool_name = item.get("name", "")
-                    params = item.get("params", {})
+                    # Support both "params" (Cursor/Windsurf) and "arguments" (OpenClaw/Claude Code)
+                    params = item.get("params", item.get("arguments", {}))
                     if tool_name.lower() in ["read_file", "readfile", "read"]:
                         # Support multiple param formats across different agents:
                         # - files: ["config.json"] (Cursor, Windsurf)


### PR DESCRIPTION
## Problem

The grader in `task_workflow.md` checks whether the agent read `config.json` by inspecting tool call parameters:

```python
params = item.get("params", {})
```

This only works for agents that serialize tool parameters under the `"params"` key (Cursor, Windsurf). **OpenClaw and Claude Code** use `"arguments"` instead — matching the OpenAI tool call spec. As a result, `read_config` always scores `0` for those agents even when they correctly read the file.

## Fix

Fall back to `"arguments"` when `"params"` is absent:

```python
# Support both "params" (Cursor/Windsurf) and "arguments" (OpenClaw/Claude Code)
params = item.get("params", item.get("arguments", {}))
```

## Verified

Confirmed by running `task_10_workflow` (pre-rename) against `kimi-k2p5` on Fireworks. The agent correctly read `config.json` — visible in the transcript — but scored `0` on `read_config` before this fix and `1.0` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)