### PR TITLE
fix(grader): strip list prefixes before extracting numbers in task_openclaw_comprehension

### DIFF
--- a/tasks/task_openclaw_comprehension.md
+++ b/tasks/task_openclaw_comprehension.md
@@ -77,9 +77,13 @@ def grade(transcript: list, workspace_path: str) -> dict:
     lines = [l.strip() for l in content.splitlines() if l.strip()]
     full_text = content.lower()
 
-    # Helper to extract numbers from text
+    # Helper to extract numbers from text.
+    # Strips leading list markers ("1. ", "2) ", etc.) so that agents which
+    # number their answers ("1. 5705") don't have the line prefix returned
+    # instead of the actual value.
     def extract_number(text):
-        numbers = re.findall(r'[\d,]+', text)
+        cleaned = re.sub(r'^\s*\d+[.)]\s+', '', text)
+        numbers = re.findall(r'[\d,]+', cleaned)
         for n in numbers:
             val = int(n.replace(',', ''))
             if val > 0:


### PR DESCRIPTION
## Problem

When an agent formats its answers as a numbered list (e.g. `1. 5705`, `2. 2999`), the `extract_number()` helper scans for the first integer in the line — which is the list prefix digit (`1`, `2`, etc.), not the actual answer:

```python
def extract_number(text):
    numbers = re.findall(r'[\d,]+', text)  # finds "1" before "5705"
    for n in numbers:
        val = int(n.replace(',', ''))
        if val > 0:
            return val  # returns 1 instead of 5705
```

This caused `total_skills` (expected 5705), `filtered_skills` (expected 2999), `top_category` (expected 287), and `second_category` (expected 253) to all score incorrectly for any agent that numbers its answers.

## Fix

Strip leading list markers before scanning for numbers:

```python
def extract_number(text):
    cleaned = re.sub(r'^\s*\d+[.)]\s+', '', text)  # strip "1. " / "2) " etc.
    numbers = re.findall(r'[\d,]+', cleaned)
    ...
```

## Verified

Discovered during `kimi-k2p5` benchmarking on Fireworks AI. The agent correctly identified all values but formatted the entire answer file as a numbered list, scoring 50% instead of ~72% due to this bug alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)