### PR TITLE
feat: add CI workflow to keep task count in README up to date

### DIFF
--- a/.github/workflows/update-task-count.yml
+++ b/.github/workflows/update-task-count.yml
@@ -1,0 +1,35 @@
+name: Update task count
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "tasks/task_*.md"
+
+jobs:
+  update-task-count:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Count tasks and update README
+        run: |
+          COUNT=$(ls tasks/task_*.md 2>/dev/null | wc -l | tr -d ' ')
+
+          # Update the badge
+          sed -i "s|<!-- task-count-badge -->.*<!-- /task-count-badge -->|<!-- task-count-badge -->![Tasks](https://img.shields.io/badge/tasks-${COUNT}-orange)<!-- /task-count-badge -->|" README.md
+
+          # Update the prose text
+          sed -i "s|<!-- task-count-text -->.*<!-- /task-count-text -->|<!-- task-count-text -->PinchBench includes ${COUNT} tasks across real-world categories:<!-- /task-count-text -->|" README.md
+
+      - name: Commit if changed
+        run: |
+          git diff --quiet README.md && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore: update task count in README [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Leaderboard](https://img.shields.io/badge/leaderboard-pinchbench.com-blue)](https://pinchbench.com)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+<!-- task-count-badge -->![Tasks](https://img.shields.io/badge/tasks-53-orange)<!-- /task-count-badge -->
 
 > **Note:** This repository contains the benchmark skill/tasks. It is NOT the source of official leaderboard results. To add models to the official results, modify [pinchbench/scripts/default-models.yml](https://github.com/pinchbench/scripts/blob/main/default-models.yml).
 
@@ -46,7 +47,7 @@ cd skill
 
 ## What Gets Tested
 
-PinchBench includes 23 tasks across real-world categories:
+<!-- task-count-text -->PinchBench includes 53 tasks across real-world categories:<!-- /task-count-text -->
 
 | Category         | Tasks                                   | What's tested                            |
 | ---------------- | --------------------------------------- | ---------------------------------------- |


### PR DESCRIPTION
## Summary

- Adds an orange **tasks** badge to the README header showing the current task count (53)
- Fixes the outdated prose text that still said "23 tasks"
- Adds a new GitHub Actions workflow (`.github/workflows/update-task-count.yml`) that automatically updates both the badge and prose count whenever `tasks/task_*.md` files change on `main`

Both the badge and text are wrapped in HTML comment markers so the CI `sed` replacement is precise and self-contained. The workflow commits with `[skip ci]` to avoid loops.