### PR TITLE
fix(judge): keep full workspace file context

### DIFF
--- a/scripts/lib_grading.py
+++ b/scripts/lib_grading.py
@@ -26,7 +26,7 @@ DEFAULT_JUDGE_AGENT_PREFIX = "bench-judge"
 DEFAULT_JUDGE_TIMEOUT_SECONDS = 300
 
 # Judge result cache: maps cache_key -> GradeResult dict
-# Cache key = hash of (task_id, transcript_summary, rubric, judge_model)
+# Cache key = hash of (task_id, transcript_summary, rubric, judge_model, workspace_content)
 _judge_cache: Dict[str, Dict[str, Any]] = {}
 _judge_cache_dir: Optional[Path] = None
 
@@ -65,9 +65,15 @@ def _save_judge_cache() -> None:
         logger.warning(f"Failed to save judge cache: {e}")
 
 
-def _compute_cache_key(task_id: str, transcript: str, rubric: str, model: str) -> str:
+def _compute_cache_key(
+    task_id: str,
+    transcript: str,
+    rubric: str,
+    model: str,
+    workspace_content: str = "",
+) -> str:
     """Compute a cache key from grading inputs."""
-    content = f"{task_id}|{transcript}|{rubric}|{model}"
+    content = f"{task_id}|{transcript}|{rubric}|{model}|{workspace_content}"
     return hashlib.sha256(content.encode()).hexdigest()[:16]
 
 
@@ -288,7 +294,13 @@ def _grade_llm_judge(
     rubric = task.llm_judge_rubric or _format_grading_criteria(task)
     
     # Check cache before calling judge
-    cache_key = _compute_cache_key(task.task_id, transcript_summary, rubric, judge_model)
+    cache_key = _compute_cache_key(
+        task.task_id,
+        transcript_summary,
+        rubric,
+        judge_model,
+        workspace_content,
+    )
     if cache_key in _judge_cache:
         cached = _judge_cache[cache_key]
         if verbose:
@@ -534,7 +546,7 @@ def _read_workspace_files(workspace_path: str) -> str:
             continue
         try:
             content = f.read_text(encoding="utf-8")
-            file_contents.append(f"### File: {rel}\n{content[:3000]}")
+            file_contents.append(f"### File: {rel}\n{content}")
         except (OSError, UnicodeDecodeError):
             pass
     return "\n\n".join(file_contents)

--- a/tests/test_lib_grading.py
+++ b/tests/test_lib_grading.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -12,8 +13,10 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 from lib_grading import (  # noqa: E402
     _combine_grades,
+    _compute_cache_key,
     _normalize_judge_response,
     _parse_judge_response,
+    _read_workspace_files,
     GradeResult,
 )
 
@@ -145,6 +148,38 @@ class JudgeNormalizationTests(unittest.TestCase):
 
         self.assertEqual(parsed["scores"]["clarity"], 0.75)
         self.assertEqual(parsed["total"], 0.8)
+
+
+class WorkspaceFilesForJudgeTests(unittest.TestCase):
+    def test_read_workspace_files_preserves_full_text_file_content(self) -> None:
+        with TemporaryDirectory() as tmp_dir:
+            workspace = Path(tmp_dir)
+            long_content = "A" * 3000 + "TAIL_MARKER"
+            (workspace / "report.md").write_text(long_content, encoding="utf-8")
+
+            content = _read_workspace_files(str(workspace))
+
+        self.assertIn("### File: report.md", content)
+        self.assertIn("TAIL_MARKER", content)
+        self.assertIn(long_content, content)
+
+    def test_compute_cache_key_changes_when_workspace_content_changes(self) -> None:
+        first_key = _compute_cache_key(
+            "task_report",
+            "same transcript",
+            "same rubric",
+            "same model",
+            "workspace version one",
+        )
+        second_key = _compute_cache_key(
+            "task_report",
+            "same transcript",
+            "same rubric",
+            "same model",
+            "workspace version two",
+        )
+
+        self.assertNotEqual(first_key, second_key)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Preserve full workspace file contents in LLM judge prompts
- Invalidate judge cache when workspace content changes
- Add regression tests for untruncated judge inputs

Fixes #96, which has serious implications on the validity of benchmark results.