### PR TITLE
fix: disable GPG signing for `task_git_rescue_recovery`

### DIFF
--- a/tasks/task_git_rescue_recovery.md
+++ b/tasks/task_git_rescue_recovery.md
@@ -92,6 +92,9 @@ def grade(transcript: list, workspace_path: str) -> dict:
             "git branch -M main",
             "git config user.name 'PinchBench'",
             "git config user.email 'bench@example.com'",
+            # RATIONALE: If user has global GPG signing enabled, this test will fail.
+            # Therefore, override the setting for this repo.
+            "git config commit.gpgsign false",
             "printf 'base\n' > app.txt",
             "git add app.txt",
             "git commit -m 'base commit'",


### PR DESCRIPTION
Fixes #387